### PR TITLE
kubectl exec: Fix deprecation warnings

### DIFF
--- a/cours/containers/kubernetes/k8s-networking.fr.md
+++ b/cours/containers/kubernetes/k8s-networking.fr.md
@@ -243,7 +243,7 @@ spec:
 kubectl get svc
 web   ClusterIP   10.96.163.5     <none>        80/TCP     3m56s
 
-kubectl exec web-96d5df5c8-lfmhs env | sort
+kubectl exec web-96d5df5c8-lfmhs -- env | sort
 WEB_PORT=tcp://10.96.163.5:80
 WEB_PORT_80_TCP=tcp://10.96.163.5:80
 WEB_PORT_80_TCP_ADDR=10.96.163.5

--- a/labs/k8s/liveness_probe.fr.md
+++ b/labs/k8s/liveness_probe.fr.md
@@ -140,7 +140,7 @@ Events:
 4. Nous allons supprimer la page d'accueil de nginx dans le conteneur, ce qui entraînera un code d'erreur 400 pour la requête http de la liveness probe :
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {.zsh .numberLines}
-kubectl exec -n healthchecking http-liveness rm /usr/share/nginx/html/index.html
+kubectl exec -n healthchecking http-liveness -- rm /usr/share/nginx/html/index.html
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 5. Au bout de quelques secondes, on devrait voir que la liveness probe échoue et le conteneur est recréé :

--- a/labs/k8s/network-policy.fr.md
+++ b/labs/k8s/network-policy.fr.md
@@ -151,8 +151,8 @@ service/source2-service created
 3. Essayons de faire une requête depuis les pods source1 et source2 vers dest :
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {.zsh .numberLines}
-kubectl exec -n network-policies -it source1-pod curl dest-service
-kubectl exec -n network-policies -it source2-pod curl dest-service
+kubectl exec -n network-policies -it source1-pod -- curl dest-service
+kubectl exec -n network-policies -it source2-pod -- curl dest-service
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {.html}

--- a/labs/k8s/secrets.fr.md
+++ b/labs/k8s/secrets.fr.md
@@ -97,7 +97,7 @@ Mounts:
 6. Vérifions que le secret est bien utilisé dans notre pod :
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {.zsh .numberLines}
-kubectl exec -it -n secrets pod-with-secret printenv
+kubectl exec -it -n secrets pod-with-secret -- printenv
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {.zsh}

--- a/tp/kube-ops/liveness_probe.md
+++ b/tp/kube-ops/liveness_probe.md
@@ -128,7 +128,7 @@ Events:
 4. Nous allons supprimer la page d'acceuil de nginx dans le conteneur, ce qui entrainera un code d'erreur 400 pour la requete http de la liveness probe :
 
 ```bash
-training@master$ kubectl exec -n healthchecking http-liveness rm /usr/share/nginx/html/index.html
+training@master$ kubectl exec -n healthchecking http-liveness -- rm /usr/share/nginx/html/index.html
 ```
 
 5. Au bout de quelques secondes, on devrait voir que la liveness probe echoue et le conteneur est recree :

--- a/tp/kube-ops/network-policy.md
+++ b/tp/kube-ops/network-policy.md
@@ -141,8 +141,8 @@ service/source2-service created
 3. Essayons de faire une requête depuis les pods source1 et source2 vers dest :
 
 ```bash
-training@master$ kubectl exec -n network-policies -it source1-pod curl dest-service
-training@master$ kubectl exec -n network-policies -it source2-pod curl dest-service
+training@master$ kubectl exec -n network-policies -it source1-pod -- curl dest-service
+training@master$ kubectl exec -n network-policies -it source2-pod -- curl dest-service
 
 <!DOCTYPE html>
 <html>

--- a/tp/kube-ops/secrets.md
+++ b/tp/kube-ops/secrets.md
@@ -87,7 +87,7 @@ Mounts:
 6. Vérifions que le secret est bien utilisé dans notre pod :
 
 ```bash
-training@master$ kubectl exec -it -n secrets pod-with-secret printenv
+training@master$ kubectl exec -it -n secrets pod-with-secret -- printenv
 
 ...
 HOSTNAME=pod-with-secret


### PR DESCRIPTION
Remove deprecation warnings like:
warn user with a deprecation message
  kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.