### PR TITLE
build: switch to Soldevelo container images (Bitnami access now paid)

### DIFF
--- a/labs/k8s/fil-rouge-troubleshoot/t10.yaml
+++ b/labs/k8s/fil-rouge-troubleshoot/t10.yaml
@@ -55,7 +55,7 @@ spec:
       serviceAccountName: monitoring-sa
       containers:
       - name: kubectl-pod
-        image: bitnami/kubectl:latest
+        image: soldevelo/kubectl:latest
         command: 
         - /bin/bash
         - -c
@@ -101,7 +101,7 @@ spec:
   serviceAccountName: monitoring-sa
   containers:
   - name: kubectl
-    image: bitnami/kubectl:latest
+    image: soldevelo/kubectl:latest
     command: 
     - sleep
     - "3600"


### PR DESCRIPTION
## Switch container base images to SolDevelo

Bitnami images now require a VMware Tanzu subscription (change effective **August 28, 2025**). This causes pipeline failures and added cost for teams that relied on the public registry.

[SolDevelo](https://hub.docker.com/u/soldevelo) provides drop-in replacements - same Debian-based images, same startup scripts, same environment-variable API - built openly from [SolDevelo/containers](https://github.com/SolDevelo/containers) and tagged to match Bitnami upstream.

## Image substitutions

- `bitnami/kubectl:latest` → [`soldevelo/kubectl:latest`](https://hub.docker.com/r/soldevelo/kubectl)